### PR TITLE
Add trigger controls and query helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project provides simple utilities for interacting with a PS5 DualSense cont
 
 - Connect to a controller over USB using the [`pydualsense`](https://pypi.org/project/pydualsense/) library.
 - Print live controller input to the terminal for debugging purposes.
+- Cycle trigger modes/forces using controller buttons and query current button
+  or joystick state through simple helper methods.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- add reentrancy-guarded helpers to cycle both trigger forces and modes
- map X/circle to R2 trigger controls and square/triangle to L2
- expose helpers for reading button, trigger, and joystick states

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68955686b5008330b122d3e4db38e4bf